### PR TITLE
Pos-tip tooltip under MS Windows

### DIFF
--- a/auto-complete.el
+++ b/auto-complete.el
@@ -1171,15 +1171,18 @@ that have been made before in this function."
             (pos-tip-hide))
           t)))))
 
+(defun ac-use-pos-tip-p ()
+  (and ac-quick-help-prefer-x
+       window-system
+       (featurep 'pos-tip)))
+
 (defun ac-quick-help (&optional force)
   (interactive)
   (when (and (or force (null this-command))
              (ac-menu-live-p)
              (null ac-quick-help))
       (setq ac-quick-help
-            (funcall (if (and ac-quick-help-prefer-x
-                              (eq window-system 'x)
-                              (featurep 'pos-tip))
+            (funcall (if (ac-use-pos-tip-p)
                          'ac-pos-tip-show-quick-help
                        'popup-menu-show-quick-help)
                      ac-menu nil
@@ -1200,9 +1203,7 @@ that have been made before in this function."
     (let ((doc (popup-item-documentation (cdr ac-last-completion)))
           (point (marker-position (car ac-last-completion))))
       (when (stringp doc)
-        (if (and ac-quick-help-prefer-x
-                 (eq window-system 'x)
-                 (featurep 'pos-tip))
+        (if (ac-use-pos-tip-p)
             (with-no-warnings (pos-tip-show doc nil point nil 0))
           (popup-tip doc
                      :point point


### PR DESCRIPTION
Currently the relevant check compares the value of `window-system' to 'x, but here it's 'w32.
I think a non-nil check should suffice.
