### PR TITLE
Hide pos-tip when completion menu closes

### DIFF
--- a/auto-complete.el
+++ b/auto-complete.el
@@ -47,6 +47,7 @@
   (require 'cl))
 
 (require 'popup)
+(require 'help-mode)
 
 ;;;; Global stuff
 


### PR DESCRIPTION
With current master, the pos-tip tooltip remains even after the completion menu has been closed.
