### PR TITLE
help-xref-following var is void if help-mode.el is autoloaded from ac-symbol-documentation

### DIFF
--- a/auto-complete.el
+++ b/auto-complete.el
@@ -47,6 +47,7 @@
   (require 'cl))
 
 (require 'popup)
+(require 'help-mode)
 
 ;;;; Global stuff
 


### PR DESCRIPTION
If help-mode.el is not already loaded, then when ac-symbol-documentation is called, the interpreter says:
    Warning: defvar ignored because help-xref-following is let-bound
After that, every call to help-buffer when help-xref-following is not let-bound fails:
    help-setup-xref: Symbol's value as variable is void: help-xref-following
