### PR TITLE
'ac-reposition' is broken

### DIFF
--- a/auto-complete.el
+++ b/auto-complete.el
@@ -1041,9 +1041,10 @@ You can not use it in source definition like (prefix . `NAME')."
 (defun ac-reposition ()
   "Force to redraw candidate menu with current `ac-candidates'."
   (let ((cursor (popup-cursor ac-menu))
-        (scroll-top (popup-scroll-top ac-menu)))
+        (scroll-top (popup-scroll-top ac-menu))
+        (height (popup-height ac-menu)))
     (ac-menu-delete)
-    (ac-menu-create ac-point (popup-preferred-width ac-candidates) (popup-height ac-menu))
+    (ac-menu-create ac-point (popup-preferred-width ac-candidates) height)
     (ac-update-candidates cursor scroll-top)))
 
 (defun ac-cleanup ()


### PR DESCRIPTION
'ac-reposition' calls 'popup-height' after ac-menu is cleared, so an error occurs like below:

<pre>
Debugger entered--Lisp error: (wrong-type-argument arrayp nil)
  popup-height(nil)
  (ac-menu-create ac-point (popup-preferred-width ac-candidates) (popup-height ac-menu))
  (let ((cursor ...) (scroll-top ...)) (ac-menu-delete) (ac-menu-create ac-point (popup-preferred-width ac-candidates) (popup-height ac-menu)) (ac-update-candidates cursor scroll-top))
  ac-reposition()
  ac-expand()
  call-interactively(ac-expand nil nil)
</pre>
