### PR TITLE
patch on popup.el ,;show    toString() :String   on menu ,but just insert ;;       toString()     in buffer ,

### DIFF
--- a/popup.el
+++ b/popup.el
@@ -130,7 +130,7 @@ SQUEEZE nil means leave whitespaces other than line breaks untouched."
   (loop with tab-width = 4
         for item in list
         for summary = (popup-item-summary item)
-        maximize (string-width (popup-x-to-string item)) into width
+        maximize (string-width (popup-x-to-string (or (get-text-property 0 'view item) item ))) into width
         if (stringp summary)
         maximize (+ (string-width summary) 2) into summary-width
         finally return (* (ceiling (/ (+ (or width 0) (or summary-width 0)) 10.0)) 10)))
@@ -362,9 +362,9 @@ See also `popup-item-propertize'."
                                                    (if (> summary-width 0)
                                                        (+ summary-width 2)
                                                      0)))))
-         (string-width (string-width string)))
+         (string-width (string-width (or (get-text-property 0 'view string) string ))))
     (concat margin-left
-            string
+            (or  (get-text-property 0 'view string) string)
             (make-string (max (- popup-width string-width summary-width) 0) ? )
             summary
             symbol


### PR DESCRIPTION
;;  when completing method ,I want to show return type behind
;;   each candidate on dropdown menu.
;;   I want to show
;;       toString() :String         on menu ,but just insert
;;       toString()                 in buffer ,
;; So I modify popup.el ,and make it support it by adding a text-property
;; named "view" to the candidate ,when the candidate has a text-property named v'iew'
;; then the value of 'view' will be showed on the dropdown menu ,when user
;; press RET or TAB ,the candidate will be inserted to buffer ,not the 'view'.
;; but if the candidate doesn't  have a property named 'view' ,it will will just;;  use the candidate itself ,so don't worry about it .
;;
and I wrote AutoJavaComplete 
    ,https://github.com/jixiuf/ajc-java-complete 
     http://www.emacswiki.org/emacs/AutoJavaComplete
it use this feature ,so I hope you can pull my code .
