### PR TITLE
Fix ac-symbol-documentation for functions in Emacs HEAD

### DIFF
--- a/auto-complete.el
+++ b/auto-complete.el
@@ -1782,8 +1782,6 @@ completion menu. This workaround stops that annoying behavior."
         (princ " is ")
         (cond
          ((fboundp symbol)
-          ;; import help-xref-following
-          (require 'help-mode)
           (describe-function-1 symbol)
           (buffer-string))
          ((boundp symbol)


### PR DESCRIPTION
Looks like 'describe-function-1 now raises an error if current-buffer
is not in help-mode, so 'ac-symbol-documentation fails to gather the info
needed for the help popup.

The fix in this commit works well for me.
