### PR TITLE
Duplicate in candidates and a 'view property

### DIFF
--- a/auto-complete.el
+++ b/auto-complete.el
@@ -292,6 +292,9 @@ a prefix doen't contain any upper case letters."
 (defvar auto-complete-mode-hook nil
   "Hook for `auto-complete-mode'.")
 
+(defvar ac-sarcasm-fork-version "0.1"
+  "Make this fork of auto-complete detectable.")
+
 
 
 ;;;; Internal variables

--- a/auto-complete.el
+++ b/auto-complete.el
@@ -264,13 +264,6 @@ a prefix doen't contain any upper case letters."
   :type 'boolean
   :group 'auto-complete)
 
-(defcustom ac-allow-duplicates nil
-  "Non-nil means allow duplicates in candidates for completion.
-
-note: this variable exist because some sources can have
-duplicates but with different actions, views, ...")
-(make-variable-buffer-local 'ac-allow-duplicates)
-
 (defcustom ac-use-menu-map nil
   "Non-nil means a special keymap `ac-menu-map' on completing menu will be used."
   :type 'boolean
@@ -998,15 +991,15 @@ You can not use it in source definition like (prefix . `NAME')."
         with case-fold-search = completion-ignore-case
         with prefix-len = (length ac-prefix)
         for source in ac-current-sources
+        if (assoc-default 'allow-dups source) sum 1 into allow-dups
         append (ac-candidates-1 source) into candidates
         finally return
         (progn
           ;; Deleting candidates with a custom test function was too
-          ;; costly. Now each buffer known to have duplicate (but
-          ;; valid) candidates can set the variable:
-          ;; `ac-allow-duplicates' to t.
-          (unless ac-allow-duplicates
-            (delete-dups candidates))
+          ;; slow. Now each source known to have valid duplicates can
+          ;; put allow-dups in the source defintion.
+          (if (zerop allow-dups)
+              (delete-dups candidates))
 
           (if (and ac-use-comphist ac-comphist)
               (if ac-show-menu

--- a/auto-complete.el
+++ b/auto-complete.el
@@ -1001,10 +1001,10 @@ You can not use it in source definition like (prefix . `NAME')."
         append (ac-candidates-1 source) into candidates
         finally return
         (progn
-          ;; Deleting candidates with a custom test function was to
-          ;; costly so now buffer know to have duplicated (but valid)
-          ;; candidates can set the variable: `ac-allow-duplicates' to
-          ;; t.
+          ;; Deleting candidates with a custom test function was too
+          ;; costly. Now each buffer known to have duplicate (but
+          ;; valid) candidates can set the variable:
+          ;; `ac-allow-duplicates' to t.
           (unless ac-allow-duplicates
             (delete-dups candidates))
 

--- a/auto-complete.el
+++ b/auto-complete.el
@@ -983,6 +983,15 @@ You can not use it in source definition like (prefix . `NAME')."
                              candidates))
     candidates))
 
+(defun ac-equal-candidates (a b)
+  "Return t if A and B are equal, otherwise nil. The comparison
+is done with a look at text properties."
+  (and (equal (popup-item-value-or-self a) (popup-item-value-or-self b))
+       (equal (popup-item-document a) (popup-item-document b))
+       (equal (popup-item-summary a) (popup-item-summary b))
+       (equal (popup-item-summary a) (popup-item-summary b))
+       (equal (popup-item-sublist a) (popup-item-sublist b))))
+
 (defun ac-candidates ()
   "Produce candidates for current sources."
   (loop with completion-ignore-case = (or (eq ac-ignore-case t)
@@ -994,7 +1003,9 @@ You can not use it in source definition like (prefix . `NAME')."
         append (ac-candidates-1 source) into candidates
         finally return
         (progn
-          (delete-dups candidates)
+          ;; FIXME: Don't know how to handle that correctly for the
+          ;; moment.
+          (delete-duplicates :test 'ac-equal-candidates)
           (if (and ac-use-comphist ac-comphist)
               (if ac-show-menu
                   (let* ((pair (ac-comphist-sort ac-comphist candidates prefix-len ac-comphist-threshold))

--- a/auto-complete.el
+++ b/auto-complete.el
@@ -991,7 +991,7 @@ You can not use it in source definition like (prefix . `NAME')."
         with case-fold-search = completion-ignore-case
         with prefix-len = (length ac-prefix)
         for source in ac-current-sources
-        if (assoc-default 'allow-dups source) sum 1 into allow-dups
+        if (assq 'allow-dups source) sum 1 into allow-dups
         append (ac-candidates-1 source) into candidates
         finally return
         (progn

--- a/auto-complete.el
+++ b/auto-complete.el
@@ -986,11 +986,9 @@ You can not use it in source definition like (prefix . `NAME')."
 (defun ac-equal-candidates (a b)
   "Return t if A and B are equal, otherwise nil. The comparison
 is done with a look at text properties."
-  (and (equal (popup-item-value-or-self a) (popup-item-value-or-self b))
-       (equal (popup-item-document a) (popup-item-document b))
-       (equal (popup-item-summary a) (popup-item-summary b))
-       (equal (popup-item-summary a) (popup-item-summary b))
-       (equal (popup-item-sublist a) (popup-item-sublist b))))
+  (and (equal a b)
+       (equal (popup-item-value a) (popup-item-value b))
+       (equal (popup-item-summary a) (popup-item-summary b))))
 
 (defun ac-candidates ()
   "Produce candidates for current sources."
@@ -1005,7 +1003,7 @@ is done with a look at text properties."
         (progn
           ;; FIXME: Don't know how to handle that correctly for the
           ;; moment.
-          (delete-duplicates candidates :test 'ac-equal-candidates)
+          (setq candidates (remove-duplicates candidates :test 'ac-equal-candidates))
           (if (and ac-use-comphist ac-comphist)
               (if ac-show-menu
                   (let* ((pair (ac-comphist-sort ac-comphist candidates prefix-len ac-comphist-threshold))

--- a/auto-complete.el
+++ b/auto-complete.el
@@ -995,9 +995,6 @@ You can not use it in source definition like (prefix . `NAME')."
         append (ac-candidates-1 source) into candidates
         finally return
         (progn
-          ;; Deleting candidates with a custom test function was too
-          ;; slow. Now each source known to have valid duplicates can
-          ;; put allow-dups in the source defintion.
           (if (zerop allow-dups)
               (delete-dups candidates))
 

--- a/auto-complete.el
+++ b/auto-complete.el
@@ -1005,7 +1005,7 @@ is done with a look at text properties."
         (progn
           ;; FIXME: Don't know how to handle that correctly for the
           ;; moment.
-          (delete-duplicates :test 'ac-equal-candidates)
+          (delete-duplicates candidates :test 'ac-equal-candidates)
           (if (and ac-use-comphist ac-comphist)
               (if ac-show-menu
                   (let* ((pair (ac-comphist-sort ac-comphist candidates prefix-len ac-comphist-threshold))

--- a/popup.el
+++ b/popup.el
@@ -130,7 +130,7 @@ SQUEEZE nil means leave whitespaces other than line breaks untouched."
   (loop with tab-width = 4
         for item in list
         for summary = (popup-item-summary item)
-        maximize (string-width (popup-x-to-string item)) into width
+        maximize (string-width (popup-x-to-string (or (get-text-property 0 'view item) item ))) into width
         if (stringp summary)
         maximize (+ (string-width summary) 2) into summary-width
         finally return (* (ceiling (/ (+ (or width 0) (or summary-width 0)) 10.0)) 10)))
@@ -362,9 +362,9 @@ See also `popup-item-propertize'."
                                                    (if (> summary-width 0)
                                                        (+ summary-width 2)
                                                      0)))))
-         (string-width (string-width string)))
+         (string-width (string-width (or (get-text-property 0 'view string) string ))))
     (concat margin-left
-            string
+            (or  (get-text-property 0 'view string) string)
             (make-string (max (- popup-width string-width summary-width) 0) ? )
             summary
             symbol

--- a/popup.el
+++ b/popup.el
@@ -239,7 +239,8 @@ SQUEEZE nil means leave whitespaces other than line breaks untouched."
                          sublist
                          document
                          symbol
-                         summary)
+                         summary
+                         view)
   "Utility function to make popup item.
 See also `popup-item-propertize'."
   (popup-item-propertize name
@@ -249,6 +250,7 @@ See also `popup-item-propertize'."
                          'document document
                          'symbol symbol
                          'summary summary
+                         'view view
                          'sublist sublist))
 
 (defsubst popup-item-value (item)               (popup-item-property item 'value))
@@ -257,6 +259,7 @@ See also `popup-item-propertize'."
 (defsubst popup-item-selection-face (item)      (popup-item-property item 'selection-face))
 (defsubst popup-item-document (item)            (popup-item-property item 'document))
 (defsubst popup-item-summary (item)             (popup-item-property item 'summary))
+(defsubst popup-item-view (item)                (popup-item-property item 'view))
 (defsubst popup-item-symbol (item)              (popup-item-property item 'symbol))
 (defsubst popup-item-sublist (item)             (popup-item-property item 'sublist))
 

--- a/popup.el
+++ b/popup.el
@@ -21,7 +21,7 @@
 
 ;;; Commentary:
 
-;; 
+;;
 
 ;;; Code:
 
@@ -124,13 +124,13 @@ SQUEEZE nil means leave whitespaces other than line breaks untouched."
        (unwind-protect
            (progn ,@body)
          (set-buffer-modified-p modified)))))
-  
+
 (defun popup-preferred-width (list)
   "Return preferred width of popup to show `LIST' beautifully."
   (loop with tab-width = 4
         for item in list
         for summary = (popup-item-summary item)
-        maximize (string-width (popup-x-to-string (or (get-text-property 0 'view item) item ))) into width
+        maximize (string-width (popup-x-to-string (or (popup-item-view item) item))) into width
         if (stringp summary)
         maximize (+ (string-width summary) 2) into summary-width
         finally return (* (ceiling (/ (+ (or width 0) (or summary-width 0)) 10.0)) 10)))
@@ -147,10 +147,10 @@ SQUEEZE nil means leave whitespaces other than line breaks untouched."
     (setq window (selected-window)))
   (unless (popup-window-full-width-p window)
     (let ((t-p-w-w (buffer-local-value 'truncate-partial-width-windows
-				       (window-buffer window))))
+                                       (window-buffer window))))
       (if (integerp t-p-w-w)
-	  (< (window-width window) t-p-w-w)
-	t-p-w-w))))
+          (< (window-width window) t-p-w-w)
+        t-p-w-w))))
 
 (defun popup-current-physical-column ()
   (or (when (and popup-use-optimized-column-computation
@@ -302,7 +302,7 @@ See also `popup-item-propertize'."
   (popup-set-filtered-list popup list)
   (setf (popup-pattern popup) nil)
   (setf (popup-original-list popup) list))
-  
+
 (defun popup-set-filtered-list (popup list)
   (setf (popup-list popup) list
         (popup-offset popup) (if (> (popup-direction popup) 0)
@@ -360,14 +360,14 @@ See also `popup-item-propertize'."
 (defun popup-create-line-string (popup string margin-left margin-right symbol summary)
   (let* ((popup-width (popup-width popup))
          (summary-width (string-width summary))
-         (string (car (popup-substring-by-width string
+         (string (car (popup-substring-by-width (or (popup-item-view string) string)
                                                 (- popup-width
                                                    (if (> summary-width 0)
                                                        (+ summary-width 2)
                                                      0)))))
-         (string-width (string-width (or (get-text-property 0 'view string) string ))))
+         (string-width (string-width string)))
     (concat margin-left
-            (or  (get-text-property 0 'view string) string)
+            string
             (make-string (max (- popup-width string-width summary-width) 0) ? )
             summary
             symbol
@@ -440,7 +440,7 @@ See also `popup-item-propertize'."
         (popup-save-buffer-state
           (goto-char (point-max))
           (insert (make-string newlines ?\n))))
-      
+
       (if overflow
           (if foldable
               (progn
@@ -459,7 +459,7 @@ See also `popup-item-propertize'."
         (setq column 0)
         (decf popup-width margin-left)
         (setq margin-left-cancel t))
-      
+
       (dotimes (i height)
         (let (overlay begin w (dangle t) (prefix "") (postfix ""))
           (when around
@@ -467,7 +467,7 @@ See also `popup-item-propertize'."
                 (vertical-motion (cons column direction))
               (vertical-motion direction)
               (move-to-column (+ (current-column) column))))
-	  (setq around t
+          (setq around t
                 current-column (popup-current-physical-column))
 
           (when (> current-column column)
@@ -497,8 +497,8 @@ See also `popup-item-propertize'."
           (overlay-put overlay 'postfix postfix)
           (overlay-put overlay 'width width)
           (aset overlays
-		(if (> direction 0) i (- height i 1))
-		overlay)))
+                (if (> direction 0) i (- height i 1))
+                overlay)))
       (loop for p from (- 10000 (* depth 1000))
             for overlay in (nreverse (append overlays nil))
             do (overlay-put overlay 'priority p))
@@ -582,11 +582,11 @@ See also `popup-item-propertize'."
                       (concat " " (or (popup-item-symbol item) " "))
                     "")
         for summary = (or (popup-item-summary item) "")
-        
+
         do
         ;; Show line and set item to the line
         (popup-set-line-item popup o item face margin-left margin-right scroll-bar-char sym summary)
-        
+
         finally
         ;; Remember current height
         (setf (popup-current-height popup) (- o offset))
@@ -815,11 +815,11 @@ See also `popup-item-propertize'."
   (and (eq margin t) (setq margin 1))
   (or margin-left (setq margin-left margin))
   (or margin-right (setq margin-right margin))
-  
+
   (let ((it (popup-fill-string string width popup-tip-max-width)))
     (setq width (car it)
           lines (cdr it)))
-  
+
   (setq tip (popup-create point width height
                           :min-height min-height
                           :around around

--- a/popup.el
+++ b/popup.el
@@ -455,7 +455,7 @@ See also `popup-item-propertize'."
         (decf column margin-left))
       (when (and (null parent)
                  (< column 0))
-          ;; Cancel margin left
+        ;; Cancel margin left
         (setq column 0)
         (decf popup-width margin-left)
         (setq margin-left-cancel t))
@@ -690,7 +690,7 @@ See also `popup-item-propertize'."
 
 (defvar popup-isearch-keymap
   (let ((map (make-sparse-keymap)))
-    ;(define-key map "\r"        'popup-isearch-done)
+    ;; (define-key map "\r"        'popup-isearch-done)
     (define-key map "\C-g"      'popup-isearch-cancel)
     (define-key map "\C-h"      'popup-isearch-delete)
     (define-key map (kbd "DEL") 'popup-isearch-delete)

--- a/popup.el
+++ b/popup.el
@@ -152,15 +152,15 @@ SQUEEZE nil means leave whitespaces other than line breaks untouched."
           (< (window-width window) t-p-w-w)
         t-p-w-w))))
 
-(defun popup-current-physical-column ()
+(defun popup-current-physical-column (&optional window)
   (or (when (and popup-use-optimized-column-computation
-                 (eq (window-hscroll) 0))
+                 (eq (window-hscroll window) 0))
         (let ((current-column (current-column)))
-          (if (or (popup-truncated-partial-width-window-p)
+          (if (or (popup-truncated-partial-width-window-p window)
                   truncate-lines
-                  (< current-column (window-width)))
+                  (< current-column (window-width window)))
               current-column)))
-      (car (posn-col-row (posn-at-point)))))
+      (car (posn-col-row (posn-at-point nil window)))))
 
 (defun popup-last-line-of-buffer-p ()
   (save-excursion (end-of-line) (/= (forward-line) 0)))


### PR DESCRIPTION
Hi,
I'm working on a source for auto-complete for C++ (with the help of the libclang).

In my pull request there is 2 'improvements' to the default auto-complete package:

- A 'view property for "popup.el"
  This string property allow a popup to display an alternative text for a popup item. 
- Allowing duplicates in sources with (allow-dups)
  For example in my source for C++ I have something like:
        (defconst ac-source-irony
        '((candidates     . (irony-ac-candidates ac-point))
          (prefix         . irony-get-completion-point)
          (requires       . 0)
          (candidate-face . ac-irony-candidate-face)
          (selection-face . ac-irony-selection-face)
          (action         . irony-ac-action)
          (allow-dups) ; <= HERE
          (cache))
        "Auto-complete source for `irony-mode'.")

The goal is to display overloaded functions and being able to select the good function immediatly (an action expand the arguments of the function).

Here are 2 screenshots of the result:
- http://ompldr.org/vYWJkdA
- http://ompldr.org/vYWJkdQ

I think C++ is *one* example where the same completion strings can mean different things and I think it's interesting to have a direct access to all of the strings (less keystrokes used IMHO).

note: the 'view property was inspired by a previous pull request (but I tried to integrate it better). I'm not sure this property is the best solution, maybe the change should be made in auto-complete.el and not in popup.el.

(I'm not really fluent in english, I hope it's not too bad.)
