### PR TITLE
Don't complete filenames if ac-prefix is a start comment delimiter

### DIFF
--- a/auto-complete.el
+++ b/auto-complete.el
@@ -1955,7 +1955,8 @@ completion menu. This workaround stops that annoying behavior."
 
 (defun ac-filename-candidate ()
   (let (file-name-handler-alist)
-    (unless (file-regular-p ac-prefix)
+    (unless (or (string-match comment-start-skip ac-prefix)
+                (file-regular-p ac-prefix))
       (ignore-errors
         (loop with dir = (file-name-directory ac-prefix)
               with files = (or (assoc-default dir ac-filename-cache)


### PR DESCRIPTION
This fixes issue 59 - http://cx4a.org/redmine/issues/59
