### PR TITLE
Fixed issue #65 (ac-symbol-documentation() not working for functions in Emacs 24)

### DIFF
--- a/auto-complete.el
+++ b/auto-complete.el
@@ -1785,7 +1785,8 @@ completion menu. This workaround stops that annoying behavior."
          ((fboundp symbol)
           ;; import help-xref-following
           (require 'help-mode)
-          (let ((help-xref-following t))
+          (let ((help-xref-following t)
+                (major-mode 'help-mode)) ; avoid error in Emacs 24
             (describe-function-1 symbol))
           (buffer-string))
          ((boundp symbol)


### PR DESCRIPTION
In Emacs 24, help-buffer() checks if current buffer is help-mode, so 'major-mode' needs to be bound to 'help-mode' before calling describe-function(). (It's unnecessary to call help-mode() to start the help-mode actually.)

I think that another solution a45aee86d7e2bfd6f5940987591f5791ca0437f8 by purcell is not good because "*Help*" buffer should be changed every time describe-function() is called.
