### PR TITLE
Fix compatibility problem with yasnippet-0.7.0

### DIFF
--- a/auto-complete-config.el
+++ b/auto-complete-config.el
@@ -143,7 +143,11 @@
   (with-no-warnings
     (if (fboundp 'yas/get-snippet-tables)
         ;; >0.6.0
-        (apply 'append (mapcar 'ac-yasnippet-candidate-1 (yas/get-snippet-tables major-mode)))
+        (if (null (help-function-arglist 'yas/get-snippet-tables))
+            ;; >0.7.0
+            (apply 'append (mapcar 'ac-yasnippet-candidate-1 (yas/get-snippet-tables)))
+          ;; 0.6.0 < x < 0.7.0
+          (apply 'append (mapcar 'ac-yasnippet-candidate-1 (yas/get-snippet-tables major-mode))))
       (let ((table
              (if (fboundp 'yas/snippet-table)
                  ;; <0.6.0


### PR DESCRIPTION
The yasnippet-0.7.0 change arguments of function yas/get-snippet-tables to null.

In discussion of issue #97 https://github.com/m2ym/auto-complete/issues/97, according to the suggestion of @julienfantin, I made this patch to fix the compatibility problem with latest yasnippet-0.7.0
