### PR TITLE
replace obsolete function princ-list 

### DIFF
--- a/etc/install.el
+++ b/etc/install.el
@@ -39,7 +39,8 @@ Add the following code to your .emacs:
                          ;(format "(add-to-list 'ac-dictionary-directories \"%s\")\n" todictdir)
                          "(ac-config-default)\n")))
         (if noninteractive
-            (princ-list msg)
+            (progn (mapc 'princ msg)
+		   (princ "\n"))
           (switch-to-buffer "*Installation Result*")
           (erase-buffer)
           (insert msg)))))))


### PR DESCRIPTION
That is what `mule-cmds.el` where it is defined has to say about it:
    (make-obsolete 'princ-list "use mapc and princ instead" "23.3")
