### PR TITLE
リクエスト: syntax table を設定可能に

### DIFF
--- a/auto-complete.el
+++ b/auto-complete.el
@@ -910,6 +910,12 @@ You can not use it in source definition like (prefix . `NAME')."
   (if ac-menu
       (popup-selected-item ac-menu)))
 
+(defmacro ac-maybe-with-syntax-table (table &rest body)
+  (declare (debug t) (indent 1))
+  `(if (syntax-table-p ,table)
+       (with-syntax-table ,table ,@body)
+     (progn ,@body)))
+
 (defun ac-prefix (requires ignore-list)
   (loop with current = (point)
         with point
@@ -918,32 +924,38 @@ You can not use it in source definition like (prefix . `NAME')."
         for source in (ac-compiled-sources)
         for prefix = (assoc-default 'prefix source)
         for req = (or (assoc-default 'requires source) requires 1)
+        for table = (assoc-default 'table source)
 
         if (null prefix-def)
         do
         (unless (member prefix ignore-list)
-          (save-excursion
-            (setq point (cond
-                         ((symbolp prefix)
-                          (funcall prefix))
-                         ((stringp prefix)
-                          (and (re-search-backward (concat prefix "\\=") nil t)
-                               (or (match-beginning 1) (match-beginning 0))))
-                         ((stringp (car-safe prefix))
-                          (let ((regexp (nth 0 prefix))
-                                (end (nth 1 prefix))
-                                (group (nth 2 prefix)))
-                            (and (re-search-backward (concat regexp "\\=") nil t)
-                                 (funcall (if end 'match-end 'match-beginning)
-                                          (or group 0)))))
-                         (t
-                          (eval prefix))))
-            (if (and point
-                     (integerp req)
-                     (< (- current point) req))
-                (setq point nil))
-            (if point
-                (setq prefix-def prefix))))
+          (ac-maybe-with-syntax-table (cond ((functionp table)
+                                             (funcall table))
+                                            (t
+                                             (eval table)))
+            (save-excursion
+              (setq point
+                    (cond
+                     ((symbolp prefix)
+                      (funcall prefix))
+                     ((stringp prefix)
+                      (and (re-search-backward (concat prefix "\\=") nil t)
+                           (or (match-beginning 1) (match-beginning 0))))
+                     ((stringp (car-safe prefix))
+                      (let ((regexp (nth 0 prefix))
+                            (end (nth 1 prefix))
+                            (group (nth 2 prefix)))
+                        (and (re-search-backward (concat regexp "\\=") nil t)
+                             (funcall (if end 'match-end 'match-beginning)
+                                      (or group 0)))))
+                     (t
+                      (eval prefix))))
+              (if (and point
+                       (integerp req)
+                       (< (- current point) req))
+                  (setq point nil))
+              (if point
+                  (setq prefix-def prefix)))))
 
         if (equal prefix prefix-def) do (push source sources)
 


### PR DESCRIPTION
新しく `table` プロパティを導入して、 syntax table を ac-source 毎に切り替えられるようにしてみました。ただ、補完自体はうまく動作してるのですが、popupの挙動がおかしくなってしまいました。

このプロパティを使えば、例えば、ドットの入った候補リストを使って似非 omni 補完的なものが出来るようになります。

以下のコードで試すことができます。

``` lisp
(require 'auto-complete-config)

(defvar my-dotty-syntax-table
  (let ((table (make-syntax-table c-mode-syntax-table)))
    (modify-syntax-entry ?. "w" table)
    (modify-syntax-entry ?_ "w" table)
    table)
  "Stolen from `python-dotty-syntax-table'.")

(ac-define-source my-dotted-source
  '((candidates . (list "Spam.Egg.Onigiri"
                        "Spam.Egg.Foo"
                        "Spam.Foo.Baz"))
    (table . my-dotty-syntax-table)))

(setq ac-sources '(ac-source-my-dotted-source))
(global-auto-complete-mode 1)
```

補完してみた結果がこれです。カーソルがなぜか popup menu の後に飛ばされてしまっています。:

<a href="http://www.flickr.com/photos/arataka/7178333104/" title="screenshot-2012-05-11-223208 by takafumi_a, on Flickr"><img src="http://farm9.staticflickr.com/8022/7178333104_7b6a52b5da.jpg" width="321" height="132" alt="screenshot-2012-05-11-223208"></a>

popwin.el は master の最新のものを使っています。
