### PR TITLE
Fix ac-yasnippet-candidates

### DIFF
--- a/auto-complete-config.el
+++ b/auto-complete-config.el
@@ -143,7 +143,11 @@
   (with-no-warnings
     (if (fboundp 'yas/get-snippet-tables)
         ;; >0.6.0
-        (apply 'append (mapcar 'ac-yasnippet-candidate-1 (yas/get-snippet-tables major-mode)))
+        (apply 'append (mapcar 'ac-yasnippet-candidate-1
+                               (condition-case nil
+                                   (yas/get-snippet-tables major-mode)
+                                 (wrong-number-of-arguments
+                                  (yas/get-snippet-tables)))))
       (let ((table
              (if (fboundp 'yas/snippet-table)
                  ;; <0.6.0


### PR DESCRIPTION
Newest version of yas/get-snippet-tables does not take any argument.
Hence the change is required.
