### PR TITLE
Proper handling of [return] and [tab] in ac-fallback-command

### DIFF
--- a/auto-complete.el
+++ b/auto-complete.el
@@ -1581,7 +1581,12 @@ that have been made before in this function."
 (defun ac-fallback-command (&optional except-command)
   (let* ((auto-complete-mode nil)
          (keys (this-command-keys-vector))
-         (command (if keys (key-binding keys))))
+         (command (and keys
+                       (or (key-binding keys)
+                           (and (equal keys [return])
+                                (key-binding "\r"))
+                           (and (equal keys [tab])
+                                (key-binding "\t"))))))
     (when (and (commandp command)
                (not (eq command except-command)))
       (setq this-command command)


### PR DESCRIPTION
ac-completing-map defines actions on [return] and [tab]. Most of the modes
define RET and TAB keys as "\r" and "\t". Thus, when ac-fallback-command searches
for a command it fails to find it when it is bound to "\r" or "\t".

This patch corrects this issue.
