### PR TITLE
Ensure that  comment-start-skip is non-nil in  ac-filename-candidate

### DIFF
--- a/auto-complete.el
+++ b/auto-complete.el
@@ -1955,7 +1955,8 @@ completion menu. This workaround stops that annoying behavior."
 
 (defun ac-filename-candidate ()
   (let (file-name-handler-alist)
-    (unless (or (string-match comment-start-skip ac-prefix)
+    (unless (or (and comment-start-skip
+                     (string-match comment-start-skip ac-prefix))
                 (file-regular-p ac-prefix))
       (ignore-errors
         (loop with dir = (file-name-directory ac-prefix)


### PR DESCRIPTION
Some modes might set comment-start-skip to nil as comments might not be  meaningfull (for
example comint buffers). In such modes ac-filename-candidate blows. This patch
solves the issue.
