### PR TITLE
Menu is distorted and ac-expand doesn't work at the end of the buffer.

### DIFF
--- a/auto-complete.el
+++ b/auto-complete.el
@@ -868,8 +868,8 @@ You can not use it in source definition like (prefix . `NAME')."
   (unless ac-prefix-overlay
     (let (newline)
       ;; Insert newline to make sure that cursor always on the overlay
-      (when (and (eq ac-point (point-max))
-                 (eq ac-point (point)))
+      (when (or (eq (point) (point-max))
+                (eq ac-point (point-max)))
         (popup-save-buffer-state
           (insert "\n"))
         (setq newline t))


### PR DESCRIPTION
When at eob, ac menu is distorted.  The cursor and inline overlay are moved
beyond the ac-menu. Consequently ac-expand (tab) doesn't work when it is invoked
repeatedly. This happens because the point is moved out of the ac-prefix-overlay
regio.  This is extremely harmful in the shell and comint buffers
when editing is always at eob.

There is already a workaround in auto-complete.el for the case when ac-point
== (point-min) == (point-max). This workaround should be also used  when
point is at eob.
