### PR TITLE
Support yasnippet 0.8

### DIFF
--- a/auto-complete-config.el
+++ b/auto-complete-config.el
@@ -21,7 +21,7 @@
 
 ;;; Commentary:
 
-;; 
+;;
 
 ;;; Code:
 
@@ -141,21 +141,26 @@
 
 (defun ac-yasnippet-candidates ()
   (with-no-warnings
-    (if (fboundp 'yas/get-snippet-tables)
-        ;; >0.6.0
-        (apply 'append (mapcar 'ac-yasnippet-candidate-1
-                               (condition-case nil
-                                   (yas/get-snippet-tables major-mode)
-                                 (wrong-number-of-arguments
-                                  (yas/get-snippet-tables)))))
-      (let ((table
-             (if (fboundp 'yas/snippet-table)
-                 ;; <0.6.0
-                 (yas/snippet-table major-mode)
-               ;; 0.6.0
-               (yas/current-snippet-table))))
-        (if table
-            (ac-yasnippet-candidate-1 table))))))
+    (cond (;; 0.8 onwards
+           (fboundp 'yas-active-keys)
+           (all-completions ac-prefix (yas-active-keys)))
+          (;; >0.6.0
+           (fboundp 'yas/get-snippet-tables)
+           (apply 'append (mapcar 'ac-yasnippet-candidate-1
+                                  (condition-case nil
+                                      (yas/get-snippet-tables major-mode)
+                                    (wrong-number-of-arguments
+                                     (yas/get-snippet-tables)))))
+           )
+          (t
+           (let ((table
+                  (if (fboundp 'yas/snippet-table)
+                      ;; <0.6.0
+                      (yas/snippet-table major-mode)
+                    ;; 0.6.0
+                    (yas/current-snippet-table))))
+             (if table
+                 (ac-yasnippet-candidate-1 table)))))))
 
 (ac-define-source yasnippet
   '((depends yasnippet)


### PR DESCRIPTION
Yasnippet has again changed its internal workings upon which `auto-complete-config.el` depends. For this I have created an "exported/exported" function `yas-active-keys` that I think provides the necessary. Notice that all "internal" symbols are now prefixed `yas--*`. Don't use those as they are subject to change.
