### PR TITLE
Fix a typo in the dict of ruby-mode

### DIFF
--- a/dict/ruby-mode
+++ b/dict/ruby-mode
@@ -129,7 +129,7 @@ in
 iterator?
 lambda
 load
-local_varaibles
+local_variables
 loop
 module
 next


### PR DESCRIPTION
Tiny improvement.
