### PR TITLE
Increase the timeout of pos-tip help menu from 5 seconds to 5 minutes 

### DIFF
--- a/auto-complete.el
+++ b/auto-complete.el
@@ -1286,7 +1286,7 @@ that have been made before in this function."
                           (and menu
                                (popup-child-point menu parent-offset))
                           (point))
-                      nil 0
+                      nil 300
                       popup-tip-max-width
                       nil nil
                       (and (not around) 0))
@@ -1337,7 +1337,7 @@ that have been made before in this function."
           (point (marker-position (car ac-last-completion))))
       (when (stringp doc)
         (if (ac-quick-help-use-pos-tip-p)
-            (with-no-warnings (pos-tip-show doc nil point nil 0))
+            (with-no-warnings (pos-tip-show doc nil point nil 300))
           (popup-tip doc
                      :point point
                      :around t


### PR DESCRIPTION
Hi guys,

I am using native popups and the most annoying part is that after the default 5 seconds it disappears. 

With the emacs 24.1.5 the 0 argument which pos-tip-show (which is passed in turn to x-show-tip) is equivalent to nil ,and thus the tip disappears after the default 5 seconds. 

This patch increases the default to 5 minutes, which should be pretty enough for everything. 
