### PR TITLE
Add ac-yasnippet.el, remove source from auto-complete-config.el.

### DIFF
--- a/auto-complete-config.el
+++ b/auto-complete-config.el
@@ -99,72 +99,6 @@
     (requires . 3)
     (symbol . "s")))
 
-;; yasnippet
-
-(defface ac-yasnippet-candidate-face
-  '((t (:background "sandybrown" :foreground "black")))
-  "Face for yasnippet candidate."
-  :group 'auto-complete)
-
-(defface ac-yasnippet-selection-face
-  '((t (:background "coral3" :foreground "white")))
-  "Face for the yasnippet selected candidate."
-  :group 'auto-complete)
-
-(defun ac-yasnippet-table-hash (table)
-  (cond
-   ((fboundp 'yas/snippet-table-hash)
-    (yas/snippet-table-hash table))
-   ((fboundp 'yas/table-hash)
-    (yas/table-hash table))))
-
-(defun ac-yasnippet-table-parent (table)
-  (cond
-   ((fboundp 'yas/snippet-table-parent)
-    (yas/snippet-table-parent table))
-   ((fboundp 'yas/table-parent)
-    (yas/table-parent table))))
-
-(defun ac-yasnippet-candidate-1 (table)
-  (with-no-warnings
-    (let ((hashtab (ac-yasnippet-table-hash table))
-          (parent (ac-yasnippet-table-parent table))
-          candidates)
-      (maphash (lambda (key value)
-                 (push key candidates))
-               hashtab)
-      (setq candidates (all-completions ac-prefix (nreverse candidates)))
-      (if parent
-          (setq candidates
-                (append candidates (ac-yasnippet-candidate-1 parent))))
-      candidates)))
-
-(defun ac-yasnippet-candidates ()
-  (with-no-warnings
-    (if (fboundp 'yas/get-snippet-tables)
-        ;; >0.6.0
-        (apply 'append (mapcar 'ac-yasnippet-candidate-1
-                               (condition-case nil
-                                   (yas/get-snippet-tables major-mode)
-                                 (wrong-number-of-arguments
-                                  (yas/get-snippet-tables)))))
-      (let ((table
-             (if (fboundp 'yas/snippet-table)
-                 ;; <0.6.0
-                 (yas/snippet-table major-mode)
-               ;; 0.6.0
-               (yas/current-snippet-table))))
-        (if table
-            (ac-yasnippet-candidate-1 table))))))
-
-(ac-define-source yasnippet
-  '((depends yasnippet)
-    (candidates . ac-yasnippet-candidates)
-    (action . yas/expand)
-    (candidate-face . ac-yasnippet-candidate-face)
-    (selection-face . ac-yasnippet-selection-face)
-    (symbol . "a")))
-
 ;; semantic
 
 (defun ac-semantic-candidates (prefix)
@@ -490,10 +424,10 @@
   )
 
 (defun ac-emacs-lisp-mode-setup ()
-  (setq ac-sources (append '(ac-source-features ac-source-functions ac-source-yasnippet ac-source-variables ac-source-symbols) ac-sources)))
+  (setq ac-sources (append '(ac-source-features ac-source-functions ac-source-variables ac-source-symbols) ac-sources)))
 
 (defun ac-cc-mode-setup ()
-  (setq ac-sources (append '(ac-source-yasnippet ac-source-gtags) ac-sources)))
+  (setq ac-sources (append '(ac-source-gtags) ac-sources)))
 
 (defun ac-ruby-mode-setup ())
 

--- a/sources/ac-yasnippet.el
+++ b/sources/ac-yasnippet.el
@@ -15,6 +15,8 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+(require 'yasnippet)
+
 (defface ac-yasnippet-candidate-face
   '((t (:background "sandybrown" :foreground "black")))
   "Face for yasnippet candidate."

--- a/sources/ac-yasnippet.el
+++ b/sources/ac-yasnippet.el
@@ -1,0 +1,59 @@
+;;; ac-yasnippet.el --- auto-complete source for yasnippet
+
+;; Copyright (C) Tomohiro Matsuyama, Alex Murray, João Távora, Christopher Monsanto
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+(defface ac-yasnippet-candidate-face
+  '((t (:background "sandybrown" :foreground "black")))
+  "Face for yasnippet candidate."
+  :group 'auto-complete)
+
+(defface ac-yasnippet-selection-face
+  '((t (:background "coral3" :foreground "white")))
+  "Face for the yasnippet selected candidate."
+  :group 'auto-complete)
+
+(defun ac-yasnippet-document (symbol)
+  ;; expand snippet in a temporary buffer
+  (let ((orig-major-mode major-mode)
+        (templates (mapcan #'(lambda (table)
+                               (yas--fetch table symbol))
+                           (yas--get-snippet-tables))))
+    (with-temp-buffer
+      (let ((major-mode orig-major-mode))
+        (insert (concatenate 'string "Snippet " symbol ":\n"))
+        ;; expand to potentially multiple options and show each
+        (dolist (template templates)
+          (insert "\n")
+          (yas-expand-snippet (yas--template-content (cdr template)))
+          (yas-exit-all-snippets)
+          ;; go to end of buffer to expand next snippet
+          ;; following this one
+          (goto-char (point-max))))
+      (buffer-string))))
+
+(defun ac-yasnippet-candidates ()
+  (all-completions ac-prefix (yas-active-keys)))
+
+(ac-define-source yasnippet
+  '((depends yasnippet)
+    (candidates . ac-yasnippet-candidates)
+    (action . yas-expand)
+    (document . ac-yasnippet-document)
+    (candidate-face . ac-yasnippet-candidate-face)
+    (selection-face . ac-yasnippet-selection-face)
+    (symbol . "a")))
+
+(provide 'ac-yasnippet)


### PR DESCRIPTION
I'm making this a pull request so we can discuss a few issues relating organization (and in case anyone wants to do a code review).

1) I think the best course of action is to have trivial sources (like this one) directly in the tree. Non-trivial sources (like emacs-auto-complete-clang, which requires building a C program) should be in a separate repo in this organization.

2) @m2ym, I figure I'll work on porting the sources in parallel with 1.x/2.0 development. I think it will be easy to switch to the new interface. Do you have the interface finalized at this point, so I can just go ahead and port "ahead of schedule"?

3) Should we have tests for sources?