### PR TITLE
Add customization variable ac-trigger-on-stop-words-when-manually

### DIFF
--- a/tests/auto-complete-test.el
+++ b/tests/auto-complete-test.el
@@ -64,3 +64,21 @@
      (ac-stop)
      (should (string= (buffer-string) "Foo"))
      )))
+
+(ert-deftest ac-test-ac-active-stop-word-p ()
+  (let ((ac-stop-words '("fi")))
+
+    (let ((ac-use-stop-words t))
+      (should (not (ac-active-stop-word-p "if")))
+      (should (ac-active-stop-word-p "fi"))
+      (should (not (ac-active-stop-word-p "fi" 'manual))))
+
+    (let ((ac-use-stop-words 'always))
+      (should (not (ac-active-stop-word-p "if")))
+      (should (ac-active-stop-word-p "fi"))
+      (should (ac-active-stop-word-p "fi" 'manual)))
+
+    (let ((ac-use-stop-words nil))
+      (should (not (ac-active-stop-word-p "if")))
+      (should (not (ac-active-stop-word-p "fi")))
+      (should (not (ac-active-stop-word-p "fi" 'manual))))))


### PR DESCRIPTION
Set it to nil can disable auto-complete on stop words.

I prefer the original behavior that completion is not started on stop words, so I add the customization variable. The default value is t and will not break current behavior.
