### PR TITLE
Fix problem that the same words are deleted even if they are from different sources.

### DIFF
--- a/auto-complete.el
+++ b/auto-complete.el
@@ -1049,7 +1049,7 @@ You can not use it in source definition like (prefix . `NAME')."
         append (ac-candidates-1 source) into candidates
         finally return
         (progn
-          (delete-dups candidates)
+          (setq candidates (delete-duplicates candidates :test #'equal-including-properties))
           (if (and ac-use-comphist ac-comphist)
               (if ac-show-menu
                   (let* ((pair (ac-comphist-sort ac-comphist candidates prefix-len ac-comphist-threshold))


### PR DESCRIPTION
Currently candidates which have the same string are deleted by the delete-dups function even if they are from different sources.  I think candidates from different sources should be handled separately and each of them should be shown on popup menu.  If the fix is valid, please merge it.
