### PR TITLE
Add `electric-buffer-list` to `ac-non-trigger-commands`.

### DIFF
--- a/auto-complete.el
+++ b/auto-complete.el
@@ -210,7 +210,8 @@
   :group 'auto-complete)
 
 (defcustom ac-non-trigger-commands
-  '(*table--cell-self-insert-command)
+  '(*table--cell-self-insert-command
+    electric-buffer-list)
   "Commands that can't be used as triggers of `auto-complete'."
   :type '(repeat symbol)
   :group 'auto-complete)


### PR DESCRIPTION
Calling `electric-buffer-list` would turn `ac-triggered` on and fire auto-complete after switching to an auto-complete enabled buffer in the electric buffer list.
