### PR TITLE
add one line to remove trailing slash of DIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ test: check-dependency
 	${EMACS} -batch -Q -l tests/run-test.el
 
 install:
+	DIR=$(patsubst %\, %, $(DIR))
 	${EMACS} -Q -L . -batch -l etc/install ${DIR}
 
 README.html: README.md


### PR DESCRIPTION
if used make install DIR=~/.emacs.d/, then the original install process will produce something like this:
(add-to-list 'ac-dictionary-directories "/Users/oxnz/.emacs.d//ac-dict"), this one line patch is to fix this problem
