### PR TITLE
Use absolute link to the manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ work.
 
 # User Manual
 
-[Auto-Complete User Manual](http://cx4a.org/software/auto-complete/#User_Manual)
+[Auto-Complete User Manual](http://cx4a.org/software/auto-complete/manual.html)
 
 # Development
 


### PR DESCRIPTION
A ton of people (see list below) click this link on GitHub, and are lead to a 
404 page. You could link to the markdown page, as is suggested at #253, but 
that won't work at the cx4a page, and anyway, that page is better rendered 
than the GitHub version.

Closes #253, closes #263, closes #262, closes #236, closes #237.
