### PR TITLE
Strip text property of inserted string

### DIFF
--- a/auto-complete.el
+++ b/auto-complete.el
@@ -1173,7 +1173,7 @@ that have been made before in this function.  When `buffer-undo-list' is
           (setq buffer-undo-list
                 (nthcdr 2 buffer-undo-list)))
       (delete-region ac-point (point)))
-    (insert string)
+    (insert (substring-no-properties string))
     ;; Sometimes, possible when omni-completion used, (insert) added
     ;; to buffer-undo-list strange record about position changes.
     ;; Delete it here:


### PR DESCRIPTION
Some face properties are remained if font-lock-defaults is nil, such as
text-mode, fundamental-mode etc.

Reproduce steps are
1. Enable `auto-complete-mode` in text-mode
2. Call `auto-complete`
3. Call ac-isearch(`C-s`)
4. Decide candidate

Then remaining `popup-isearch-match` face property as below.

![auto-complete-remaining-face-property](https://f.cloud.github.com/assets/554281/1590061/1c6a62c8-5285-11e3-85ba-58770d88b3cd.png)
