### PR TITLE
Add customizable variable 'max-width' same as #202

### DIFF
--- a/auto-complete.el
+++ b/auto-complete.el
@@ -303,6 +303,13 @@ a prefix doen't contain any upper case letters."
   :type 'integer
   :group 'auto-complete)
 
+(defcustom ac-max-width nil
+  "Maximum width for auto-complete menu to have"
+  :type '(choice (const :tag "No limit" nil)
+                 (const :tag "Character Limit" 25)
+                 (const :tag "Window Ratio Limit" 0.5))
+  :group 'auto-complete)
+
 (defface ac-completion-face
   '((t (:foreground "darkgray" :underline t)))
   "Face for inline completion"
@@ -797,6 +804,7 @@ You can not use it in source definition like (prefix . `NAME')."
         (popup-create point width height
                       :around t
                       :face 'ac-candidate-face
+                      :max-width ac-max-width
                       :mouse-face 'ac-candidate-mouse-face
                       :selection-face 'ac-selection-face
                       :symbol t


### PR DESCRIPTION
`popup-el` supports `max-width` property, so we can use `max-width` in `auto-complete`.

Cc: @toumorokoshi
