### PR TITLE
Add autoload cookies

### DIFF
--- a/auto-complete.el
+++ b/auto-complete.el
@@ -1710,6 +1710,7 @@ that have been made before in this function.  When `buffer-undo-list' is
           ad-do-it))
     (ad-disable-advice 'flymake-on-timer-event 'around 'ac-flymake-stop-advice)))
 
+;;;###autoload
 (define-minor-mode auto-complete-mode
   "AutoComplete mode"
   :lighter " AC"
@@ -1733,6 +1734,7 @@ that have been made before in this function.  When `buffer-undo-list' is
            (memq major-mode ac-modes))
       (auto-complete-mode 1)))
 
+;;;###autoload
 (define-global-minor-mode global-auto-complete-mode
   auto-complete-mode auto-complete-mode-maybe
   :group 'auto-complete)


### PR DESCRIPTION
This commit ensures that users who have installed `auto-complete` with `package.el` will be able to use the code without explicitly requiring the library first.
