### PR TITLE
Remove quick-help when updating popup(#279)

### DIFF
--- a/auto-complete.el
+++ b/auto-complete.el
@@ -1254,6 +1254,7 @@ that have been made before in this function.  When `buffer-undo-list' is
                 (and (> (popup-direction ac-menu) 0)
                      (ac-menu-at-wrapper-line-p)))
         (ac-inline-hide) ; Hide overlay to calculate correct column
+        (ac-remove-quick-help)
         (ac-menu-delete)
         (ac-menu-create ac-point preferred-width ac-menu-height)))
     (ac-update-candidates 0 0)


### PR DESCRIPTION
@AltGr I think #279 issue is fixed by applying this patch.

Please check this `auto-complete.el` version.

https://raw.github.com/auto-complete/auto-complete/fix-popup-broken-issue/auto-complete.el
