### PR TITLE
Don't complete when (region-active-p).

### DIFF
--- a/auto-complete.el
+++ b/auto-complete.el
@@ -1718,7 +1718,8 @@ that have been made before in this function.  When `buffer-undo-list' is
                      ac-completing)
                  (not isearch-mode))
         (setq ac-last-point (point))
-        (ac-start :requires (unless ac-completing ac-auto-start))
+        (unless (region-active-p)
+          (ac-start :requires (unless ac-completing ac-auto-start)))
         (unless ac-disable-inline
           (ac-inline-update)))
     (error (ac-error var))))


### PR DESCRIPTION
Hi,

Maybe it's a bit contrived to check if the region is active,
but I'm pretty sure no one would want to auto-complete in that case.

My use case is that I've bound "m" to a command that either self-inserts or marks sexp.
I've added it to `ac-trigger-commands` because I want to auto-complete after self-inserting,
but I don't want to auto-complete after marking.
