### PR TITLE
Fixed flycheck workaround when completion is aborted(#300)

### DIFF
--- a/auto-complete.el
+++ b/auto-complete.el
@@ -1709,7 +1709,7 @@ that have been made before in this function.  When `buffer-undo-list' is
 (defun ac-syntax-checker-workaround ()
   (if ac-stop-flymake-on-completing
       (progn
-	(make-variable-buffer-local ac-flycheck-poll-completion-end-timer)
+	(make-variable-buffer-local 'ac-flycheck-poll-completion-end-timer)
 	(when (require 'flymake nil t)
 	  (defadvice flymake-on-timer-event (around ac-flymake-stop-advice activate)
 	    (unless ac-completing


### PR DESCRIPTION
Thank you for issue reopening. I fixed behavior when completion is aborted.

Fixed points:
- I made to start flycheck's syntax checking when completion is aborted too.
  - I add timer to detect completion is aborted.
  - I add user customizable variable to custom above timer's polling interval.
- I made to load Flymake and Flycheck (if exist) before `defadvice`.
- I splited function `ac-setup` for `ac-syntax-checker-workaround` because it becomes long.
