### PR TITLE
Fix typo for the onmouseover font.

### DIFF
--- a/auto-complete.el
+++ b/auto-complete.el
@@ -321,7 +321,7 @@ a prefix doen't contain any upper case letters."
   :group 'auto-complete)
 
 (defface ac-candidate-mouse-face
-  '((t (:inherit popup-mouse-face)))
+  '((t (:inherit popup-menu-mouse-face)))
   "Mouse face for candidate."
   :group 'auto-complete)
 


### PR DESCRIPTION
This typo is causing org-html-htmlize-generate-css to fail as reported in the link below. https://lists.gnu.org/archive/html/emacs-orgmode/2013-03/msg00227.html
