### PR TITLE
Don't overwritten ac-triggered value(#286)

### DIFF
--- a/auto-complete.el
+++ b/auto-complete.el
@@ -1675,7 +1675,8 @@ that have been made before in this function.  When `buffer-undo-list' is
                                           (ac-trigger-command-p this-command)
                                           (and ac-completing
                                                (memq this-command ac-trigger-commands-on-completing)))
-                                      (not (ac-cursor-on-diable-face-p))))
+                                      (not (ac-cursor-on-diable-face-p))
+                                      (or ac-triggered t)))
               (ac-compatible-package-command-p this-command))
           (progn
             (if (or (not (symbolp this-command))


### PR DESCRIPTION
`ac-triggered` value should not be overwritten with `t` if its previous
value is `'command`.

@immerrr Could you check this version ? 

https://github.com/auto-complete/auto-complete/blob/not-stop-dictionary-word/auto-complete.el
