### PR TITLE
added tcl-mode to custom ac-modes

### DIFF
--- a/auto-complete.el
+++ b/auto-complete.el
@@ -192,7 +192,7 @@
     java-mode malabar-mode clojure-mode clojurescript-mode  scala-mode
     scheme-mode
     ocaml-mode tuareg-mode coq-mode haskell-mode agda-mode agda2-mode
-    perl-mode cperl-mode python-mode ruby-mode lua-mode
+    perl-mode cperl-mode python-mode ruby-mode lua-mode tcl-mode
     ecmascript-mode javascript-mode js-mode js2-mode php-mode css-mode
     makefile-mode sh-mode fortran-mode f90-mode ada-mode
     xml-mode sgml-mode


### PR DESCRIPTION
Noticed auto-complete does not work for tcl. This is one of the two steps to fix the problem in GNU Emacs 23.3.1 (i686-pc-linux-gnu, GTK+ Version 2.24.10) running on Ubuntu 12.04.
