### PR TITLE
added tcl to ac-config default

### DIFF
--- a/auto-complete-config.el
+++ b/auto-complete-config.el
@@ -513,6 +513,7 @@
   (add-hook 'c-mode-common-hook 'ac-cc-mode-setup)
   (add-hook 'ruby-mode-hook 'ac-ruby-mode-setup)
   (add-hook 'css-mode-hook 'ac-css-mode-setup)
+  (add-hook 'tcl-mode-hook 'ac-tcl-mode-setup)
   (add-hook 'auto-complete-mode-hook 'ac-common-setup)
   (global-auto-complete-mode t))
 


### PR DESCRIPTION
Noticed auto-complete does not work for tcl. This is one of the two steps to fix the problem in GNU Emacs 23.3.1 (i686-pc-linux-gnu, GTK+ Version 2.24.10) running on Ubuntu 12.04.
