### PR TITLE
Have 'action function' accpet an argument if it there (2)

### DIFF
--- a/auto-complete.el
+++ b/auto-complete.el
@@ -1557,7 +1557,7 @@ function with `&rest' args."
              (funcall action selected-name))
             (t (funcall action))))
      (fallback
-      (ac-fallbgack-command)))
+      (ac-fallback-command)))
     candidate))
 
 (defun ac-complete ()


### PR DESCRIPTION
If an action function has one argument, the action function's first argument will be the selected candidate name.

For example:

``` cl
(ac-define-source my-test-1
  '((candidates . '("test1" "test2" "test3"))
    (action . (lambda ($selected) (message (format "----- %s -----" $selected))))))
(add-to-list 'ac-sources 'ac-source-my-test-1)
```

When "test1" completed with RET key, a message "----- test1 -----" is going to display on the mini buffer.
