### PR TITLE
Added ac-delete-dups

### DIFF
--- a/auto-complete.el
+++ b/auto-complete.el
@@ -311,6 +311,11 @@ a prefix doen't contain any upper case letters."
                  (const :tag "Window Ratio Limit" 0.5))
   :group 'auto-complete)
 
+(defcustom ac-delete-dups t
+  "Non-nil automatically deletes duplicate candidates"
+  :type 'boolean
+  :group 'auto-complete)
+
 (defface ac-completion-face
   '((t (:foreground "darkgray" :underline t)))
   "Face for inline completion"
@@ -1064,7 +1069,8 @@ You can not use it in source definition like (prefix . `NAME')."
         append (ac-candidates-1 source) into candidates
         finally return
         (progn
-          (delete-dups candidates)
+          (when ac-delete-dups
+            (delete-dups candidates))
           (if (and ac-use-comphist ac-comphist)
               (if ac-show-menu
                   (let* ((pair (ac-comphist-sort ac-comphist candidates prefix-len ac-comphist-threshold))


### PR DESCRIPTION
This is a simple change allows dealing with duplicate candidates like mentioned in #312.

The default behavior of auto-complete remains as it is now but allows for developers to turn off duplicate deletion if they want. If they do this they become responsible for providing a visual way to disambiguate the duplicates (e.g. the summary property).

My use case for this very similar to that presented in #312. My backend delivers me a list of possible method completions and the method names can be duplicated because of overloading. The completion text is the method name and the disambigutation is the method signature in the summary property. I have a custom action that optionally inserts a template for the method arguments after the method name has been inserted by auto-complete. 

This simple approach doesn't have any adverse performance effects and doesn't introduce any magical logic for determining duplicates (like matching on all properties or some subset of properties). 