### PR TITLE
Don't exclude sources because of different prefix parsers.

### DIFF
--- a/auto-complete.el
+++ b/auto-complete.el
@@ -965,13 +965,13 @@ You can not use it in source definition like (prefix . `NAME')."
 (defun ac-prefix (requires ignore-list)
   (loop with current = (point)
         with point
+        with point-def
         with prefix-def
         with sources
         for source in (ac-compiled-sources)
         for prefix = (assoc-default 'prefix source)
         for req = (or (assoc-default 'requires source) requires 1)
 
-        if (null prefix-def)
         do
         (unless (member prefix ignore-list)
           (save-excursion
@@ -994,10 +994,12 @@ You can not use it in source definition like (prefix . `NAME')."
                      (integerp req)
                      (< (- current point) req))
                 (setq point nil))
-            (if point
-                (setq prefix-def prefix))))
-
-        if (equal prefix prefix-def) do (push source sources)
+            (when point
+                (if (null prefix-def)
+                    (setq prefix-def prefix
+                          point-def point))
+                (if (equal point point-def)
+                    (push source sources)))))
 
         finally return
         (and point (list prefix-def point (nreverse sources)))))


### PR DESCRIPTION
The current policy is too disruptive. Any source could break all other sources because it wants to implement its own prefix parser. But there is no point in excluding, say, words in current or all buffers, yasnippet, etc. Why not letting each source parse with its own prefix?

PS: [here](https://github.com/ScottyB/ac-js2/issues/13) is an example of the problems caused by the current source selection logic.