### PR TITLE
Remove duplicates on a per-source basis.

### DIFF
--- a/auto-complete.el
+++ b/auto-complete.el
@@ -1066,29 +1066,29 @@ You can not use it in source definition like (prefix . `NAME')."
         with case-fold-search = completion-ignore-case
         with prefix-len = (length ac-prefix)
         for source in ac-current-sources
-        append (ac-candidates-1 source) into candidates
+        ;; Delete duplicates from the same source, but allow multiple sources to
+        ;; provide the same candidate completion.
+        append (delete-dups (ac-candidates-1 source)) into candidates
         finally return
-        (progn
-          (delete-dups candidates)
-          (if (and ac-use-comphist ac-comphist)
-              (if ac-show-menu
-                  (let* ((pair (ac-comphist-sort ac-comphist candidates prefix-len ac-comphist-threshold))
-                         (n (car pair))
-                         (result (cdr pair))
-                         (cons (if (> n 0) (nthcdr (1- n) result)))
-                         (cdr (cdr cons)))
-                    (if cons (setcdr cons nil))
-                    (setq ac-common-part (try-completion ac-prefix result))
-                    (setq ac-whole-common-part (try-completion ac-prefix candidates))
-                    (if cons (setcdr cons cdr))
-                    result)
-                (setq candidates (ac-comphist-sort ac-comphist candidates prefix-len))
-                (setq ac-common-part (if candidates (popup-x-to-string (car candidates))))
-                (setq ac-whole-common-part (try-completion ac-prefix candidates))
-                candidates)
-            (setq ac-common-part (try-completion ac-prefix candidates))
-            (setq ac-whole-common-part ac-common-part)
-            candidates))))
+        (if (and ac-use-comphist ac-comphist)
+            (if ac-show-menu
+                (let* ((pair (ac-comphist-sort ac-comphist candidates prefix-len ac-comphist-threshold))
+                       (n (car pair))
+                       (result (cdr pair))
+                       (cons (if (> n 0) (nthcdr (1- n) result)))
+                       (cdr (cdr cons)))
+                  (if cons (setcdr cons nil))
+                  (setq ac-common-part (try-completion ac-prefix result))
+                  (setq ac-whole-common-part (try-completion ac-prefix candidates))
+                  (if cons (setcdr cons cdr))
+                  result)
+              (setq candidates (ac-comphist-sort ac-comphist candidates prefix-len))
+              (setq ac-common-part (if candidates (popup-x-to-string (car candidates))))
+              (setq ac-whole-common-part (try-completion ac-prefix candidates))
+              candidates)
+          (setq ac-common-part (try-completion ac-prefix candidates))
+          (setq ac-whole-common-part ac-common-part)
+          candidates)))
 
 (defun ac-update-candidates (cursor scroll-top)
   "Update candidates of menu to `ac-candidates' and redraw it."


### PR DESCRIPTION
This attempts to fix the issue of two candidates being considered duplicates even if they come from different sources. DELETE-DUPS is now called before the result of AC-CANDIDATES-1 is appended into the list of candidates.

This should be faster than the solution proposed in #247 (and in most cases faster than the original implementation) and should solve #337. This could (should?) possibly be combined with #340 as well.