### PR TITLE
Fix blinking cursor when no match is found

### DIFF
--- a/auto-complete.el
+++ b/auto-complete.el
@@ -1483,10 +1483,10 @@ that have been made before in this function.  When `buffer-undo-list' is
     (unless (ac-menu-live-p)
       (ac-start))
     (let ((ac-match-function 'fuzzy-all-completions))
-      (unless ac-cursor-color
-        (setq ac-cursor-color (frame-parameter (selected-frame) 'cursor-color)))
-      (if ac-fuzzy-cursor-color
-          (set-cursor-color ac-fuzzy-cursor-color))
+      (when ac-fuzzy-cursor-color
+        (unless ac-cursor-color
+          (setq ac-cursor-color (frame-parameter (selected-frame) 'cursor-color)))
+        (set-cursor-color ac-fuzzy-cursor-color))
       (setq ac-show-menu t)
       (setq ac-fuzzy-enable t)
       (setq ac-triggered nil)
@@ -1598,8 +1598,9 @@ If given a prefix argument, select the previous candidate."
                      (ac-stop-word-p prefix))))
           (prog1 nil
             (ac-abort))
-        (unless ac-cursor-color
-          (setq ac-cursor-color (frame-parameter (selected-frame) 'cursor-color)))
+        (when (and ac-use-fuzzy ac-fuzzy-cursor-color)
+          (unless ac-cursor-color
+            (setq ac-cursor-color (frame-parameter (selected-frame) 'cursor-color))))
         (setq ac-show-menu (or ac-show-menu (if (eq ac-auto-show-menu t) t))
               ac-current-sources sources
               ac-buffer (current-buffer)


### PR DESCRIPTION
ac-cursor-color was set by ac-start() even though it is only relevant when fuzzy matching is on, and additionally only when ac-fuzzy-cursor-color is non-nil.  Because it was getting set,  ac-cleanup() was always calling set-cursor-color().  That ought to be a no-op when fuzzy matching is off (since the cursor color was never actually changed) but at least on OSX this causes a brief but noticeable cursor blink (in all buffers).

I believe this should fix:
- Issue #351
- http://stackoverflow.com/questions/21793920/stop-emacs-auto-complete-from-flashing-cursor-in-other-windows
- http://stackoverflow.com/questions/24227855/auto-complete-mode-on-emacs-for-mac-os-x

To test, I opened emacs on OSX and typed aaaaaaaaaaaaa in the scratch buffer.  Previously, the cursor would blink with every keystroke.  With this patch it doesn't.