### PR TITLE
Fix case when multiple source has 'prefix' parameter

### DIFF
--- a/auto-complete.el
+++ b/auto-complete.el
@@ -1010,7 +1010,7 @@ You can not use it in source definition like (prefix . `NAME')."
                     (push source sources)))))
 
         finally return
-        (and point (list prefix-def point (nreverse sources)))))
+        (and point-def (list prefix-def point-def (nreverse sources)))))
 
 (defun ac-init ()
   "Initialize current sources to start completion."


### PR DESCRIPTION
'point' variable is overwritten with last source which has
prefix parameter. So we should use 'point-def' instead of 'point'.

This is related to #387.

`auto-complete` works as expected(#387) with this change.
![auto-complete](https://cloud.githubusercontent.com/assets/554281/5991327/95dfb1be-aa2a-11e4-859d-23b8eed43951.png)

