### PR TITLE
Add missing nil.

### DIFF
--- a/auto-complete.el
+++ b/auto-complete.el
@@ -834,7 +834,7 @@ You can not use it in source definition like (prefix . `NAME')."
 (defun ac-menu-delete ()
   (when ac-menu
     (popup-delete ac-menu)
-    (setq ac-menu)))
+    (setq ac-menu nil)))
 
 (defsubst ac-inline-overlay ()
   (nth 0 ac-inline))


### PR DESCRIPTION
Now Emacs didn't allow using setq with one argument. For the detailed discussion, please see http://debbugs.gnu.org/cgi/bugreport.cgi?bug=20241.

Thanks.