### PR TITLE
Remove `enumerat' from python-mode dictionary

### DIFF
--- a/dict/python-mode
+++ b/dict/python-mode
@@ -146,7 +146,6 @@ email
 enumerate
 ensurepip
 enum
-enumerat
 errno
 eval
 except


### PR DESCRIPTION
Isn't this a typo?
I didn't find any valid use cases from a few minutes of googling.