### PR TITLE
Add JSX modes

### DIFF
--- a/auto-complete.el
+++ b/auto-complete.el
@@ -204,7 +204,8 @@ Use `version-to-list' to get version component.")
     scheme-mode
     ocaml-mode tuareg-mode coq-mode haskell-mode agda-mode agda2-mode
     perl-mode cperl-mode python-mode ruby-mode lua-mode tcl-mode
-    ecmascript-mode javascript-mode js-mode js2-mode php-mode css-mode scss-mode less-css-mode
+    ecmascript-mode javascript-mode js-mode js-jsx-mode js2-mode js2-jsx-mode
+    php-mode css-mode scss-mode less-css-mode
     makefile-mode sh-mode fortran-mode f90-mode ada-mode
     xml-mode sgml-mode web-mode
     ts-mode


### PR DESCRIPTION
Adds support for `js-jsx-mode` and `js2-jsx-mode`. These modes provide syntax extensions to `js-mode` and `js2-mode`, so they are also programming modes probably worthy of auto-completion.