### PR TITLE
Add elixir-mode to ac-modes

### DIFF
--- a/auto-complete.el
+++ b/auto-complete.el
@@ -206,6 +206,7 @@ Use `version-to-list' to get version component.")
     perl-mode cperl-mode python-mode ruby-mode lua-mode tcl-mode
     ecmascript-mode javascript-mode js-mode js-jsx-mode js2-mode js2-jsx-mode
     php-mode css-mode scss-mode less-css-mode
+    elixir-mode
     makefile-mode sh-mode fortran-mode f90-mode ada-mode
     xml-mode sgml-mode web-mode
     ts-mode


### PR DESCRIPTION
elixir-mode provides support for a programming language called Elixir, which could also probably benefit from auto completion.