### PR TITLE
ignore non-decimal numerals in ac-prefix-default

### DIFF
--- a/auto-complete.el
+++ b/auto-complete.el
@@ -701,13 +701,12 @@ If there is no common part, this will be nil.")
 
 (defun ac-prefix-default ()
   "Same as `ac-prefix-symbol' but ignore a number prefix."
-  (let ((start (ac-prefix-symbol)))
-    (when start
-      (cl-loop with end = (point)
-            for pos from start below end
-            for c = (char-after pos)
-            if (not (and (<= ?0 c) (<= c ?9)))
-            return start))))
+  (let ((start (ac-prefix-symbol))
+        (case-fold-search t))
+    (when (and start
+             (not (string-match "^\\(?:0[xbo][0-9a-f]+\\|[0-9]+\\)$"
+                              (buffer-substring-no-properties start (point)))))
+      start)))
 
 (defun ac-prefix-symbol ()
   "Default prefix definition function."

--- a/auto-complete.el
+++ b/auto-complete.el
@@ -704,8 +704,8 @@ If there is no common part, this will be nil.")
   (let ((start (ac-prefix-symbol))
         (case-fold-search t))
     (when (and start
-             (not (string-match "^\\(?:0[xbo][0-9a-f]+\\|[0-9]+\\)$"
-                              (buffer-substring-no-properties start (point)))))
+             (not (string-match-p "\\`\\(?:0[xbo][0-9a-f]+\\|[0-9]+\\)"
+                                (buffer-substring-no-properties start (point)))))
       start)))
 
 (defun ac-prefix-symbol ()


### PR DESCRIPTION
Prevents completing common non-decimal numeral notations (e.g. 0xff, 0o777, 0b1010).