### PR TITLE
Update ac-css-property-alist with css3 properties

### DIFF
--- a/auto-complete-config.el
+++ b/auto-complete-config.el
@@ -264,7 +264,8 @@
 
 ;; css
 
-;; Copied from company-css.el
+;; Property list borrowed from Company, source:
+;; https://github.com/company-mode/company-mode/blob/master/company-css.el
 (defconst ac-css-property-alist
   ;; see http://www.w3.org/TR/CSS21/propidx.html
   '(("azimuth" angle "left-side" "far-left" "left" "center-left" "center"

--- a/auto-complete-config.el
+++ b/auto-complete-config.el
@@ -271,7 +271,8 @@
      "center-right" "right" "far-right" "right-side" "behind" "leftwards"
      "rightwards")
     ("background" background-color background-image background-repeat
-     background-attachment background-position)
+     background-attachment background-position
+     background-clip background-origin background-size)
     ("background-attachment" "scroll" "fixed")
     ("background-color" color "transparent")
     ("background-image" uri "none")
@@ -324,13 +325,14 @@
     ("elevation" angle "below" "level" "above" "higher" "lower")
     ("empty-cells" "show" "hide")
     ("float" "left" "right" "none")
-    ("font" font-style font-variant font-weight font-size "/" line-height
+    ("font" font-style font-weight font-size "/" line-height
      font-family "caption" "icon" "menu" "message-box" "small-caption"
-     "status-bar")
+     "status-bar" "normal" "small-caps"
+     ;; CSS3
+     font-stretch)
     ("font-family" family-name generic-family)
     ("font-size" absolute-size relative-size length percentage)
     ("font-style" "normal" "italic" "oblique")
-    ("font-variant" "normal" "small-caps")
     ("font-weight" "normal" "bold" "bolder" "lighter" "100" "200" "300" "400"
      "500" "600" "700" "800" "900")
     ("height" length percentage "auto")
@@ -357,7 +359,9 @@
     ("outline-color" color "invert")
     ("outline-style" border-style)
     ("outline-width" border-width)
-    ("overflow" "visible" "hidden" "scroll" "auto")
+    ("overflow" "visible" "hidden" "scroll" "auto"
+     ;; CSS3:
+     "no-display" "no-content")
     ("padding" padding-width)
     ("padding-bottom" padding-width)
     ("padding-left" padding-width)
@@ -385,7 +389,6 @@
     ("stress" number)
     ("table-layout" "auto" "fixed")
     ("text-align" "left" "right" "center" "justify")
-    ("text-decoration" "none" "underline" "overline" "line-through" "blink")
     ("text-indent" length percentage)
     ("text-transform" "capitalize" "uppercase" "lowercase" "none")
     ("top" length percentage "auto")
@@ -401,26 +404,151 @@
     ("widows" integer)
     ("width" length percentage "auto")
     ("word-spacing" "normal" length)
-    ("z-index" "auto" integer))
+    ("z-index" "auto" integer)
+    ;; CSS3
+    ("align-content" align-stretch "space-between" "space-around")
+    ("align-items" align-stretch "baseline")
+    ("align-self" align-items "auto")
+    ("animation" animation-name animation-duration animation-timing-function
+     animation-delay animation-iteration-count animation-direction
+     animation-fill-mode)
+    ("animation-delay" time)
+    ("animation-direction" "normal" "reverse" "alternate" "alternate-reverse")
+    ("animation-duration" time)
+    ("animation-fill-mode" "none" "forwards" "backwards" "both")
+    ("animation-iteration-count" integer "infinite")
+    ("animation-name" "none")
+    ("animation-play-state" "paused" "running")
+    ("animation-timing-function" transition-timing-function
+     "step-start" "step-end" "steps(,)")
+    ("backface-visibility" "visible" "hidden")
+    ("background-clip" background-origin)
+    ("background-origin" "border-box" "padding-box" "content-box")
+    ("background-size" length percentage "auto" "cover" "contain")
+    ("border-image" border-image-outset border-image-repeat border-image-source
+     border-image-slice border-image-width)
+    ("border-image-outset" length)
+    ("border-image-repeat" "stretch" "repeat" "round" "space")
+    ("border-image-source" uri "none")
+    ("border-image-slice" length)
+    ("border-image-width" length percentage)
+    ("border-radius" length)
+    ("border-top-left-radius" length)
+    ("border-top-right-radius" length)
+    ("border-bottom-left-radius" length)
+    ("border-bottom-right-radius" length)
+    ("box-decoration-break" "slice" "clone")
+    ("box-shadow" length color)
+    ("box-sizing" "content-box" "border-box")
+    ("break-after" "auto" "always" "avoid" "left" "right" "page" "column"
+     "avoid-page" "avoid-column")
+    ("break-before" break-after)
+    ("break-inside" "avoid" "auto")
+    ("columns" column-width column-count)
+    ("column-count" integer)
+    ("column-fill" "auto" "balance")
+    ("column-gap" length "normal")
+    ("column-rule" column-rule-width column-rule-style column-rule-color)
+    ("column-rule-color" color)
+    ("column-rule-style" border-style)
+    ("column-rule-width" border-width)
+    ("column-span" "all" "none")
+    ("column-width" length "auto")
+    ("filter" url "blur()" "brightness()" "contrast()" "drop-shadow()"
+     "grayscale()" "hue-rotate()" "invert()" "opacity()" "saturate()" "sepia()")
+    ("flex" flex-grow flex-shrink flex-basis)
+    ("flex-basis" percentage length "auto")
+    ("flex-direction" "row" "row-reverse" "column" "column-reverse")
+    ("flex-flow" flex-direction flex-wrap)
+    ("flex-grow" number)
+    ("flex-shrink" number)
+    ("flex-wrap" "nowrap" "wrap" "wrap-reverse")
+    ("font-feature-setting" normal string number)
+    ("font-kerning" "auto" "normal" "none")
+    ("font-language-override" "normal" string)
+    ("font-size-adjust" "none" number)
+    ("font-stretch" "normal" "ultra-condensed" "extra-condensed" "condensed"
+     "semi-condensed" "semi-expanded" "expanded" "extra-expanded" "ultra-expanded")
+    ("font-synthesis" "none" "weight" "style")
+    ("font-variant" font-variant-alternates font-variant-caps
+     font-variant-east-asian font-variant-ligatures font-variant-numeric
+     font-variant-position)
+    ("font-variant-alternates" "normal" "historical-forms" "stylistic()"
+     "styleset()" "character-variant()" "swash()" "ornaments()" "annotation()")
+    ("font-variant-caps" "normal" "small-caps" "all-small-caps" "petite-caps"
+     "all-petite-caps" "unicase" "titling-caps")
+    ("font-variant-east-asian" "jis78" "jis83" "jis90" "jis04" "simplified"
+     "traditional" "full-width" "proportional-width" "ruby")
+    ("font-variant-ligatures" "normal" "none" "common-ligatures"
+     "no-common-ligatures" "discretionary-ligatures" "no-discretionary-ligatures"
+     "historical-ligatures" "no-historical-ligatures" "contextual" "no-contextual")
+    ("font-variant-numeric" "normal" "ordinal" "slashed-zero"
+     "lining-nums" "oldstyle-nums" "proportional-nums" "tabular-nums"
+     "diagonal-fractions" "stacked-fractions")
+    ("font-variant-position" "normal" "sub" "super")
+    ("hyphens" "none" "manual" "auto")
+    ("justify-content" align-common "space-between" "space-around")
+    ("line-break" "auto" "loose" "normal" "strict")
+    ("marquee-direction" "forward" "reverse")
+    ("marquee-play-count" integer "infinite")
+    ("marquee-speed" "slow" "normal" "fast")
+    ("marquee-style" "scroll" "slide" "alternate")
+    ("opacity" number)
+    ("order" number)
+    ("outline-offset" length)
+    ("overflow-x" overflow)
+    ("overflow-y" overflow)
+    ("overflow-style" "auto" "marquee-line" "marquee-block")
+    ("overflow-wrap" "normal" "break-word")
+    ("perspective" "none" length)
+    ("perspective-origin" percentage length "left" "center" "right" "top" "bottom")
+    ("resize" "none" "both" "horizontal" "vertical")
+    ("tab-size" integer length)
+    ("text-align-last" "auto" "start" "end" "left" "right" "center" "justify")
+    ("text-decoration" text-decoration-color text-decoration-line text-decoration-style)
+    ("text-decoration-color" color)
+    ("text-decoration-line" "none" "underline" "overline" "line-through" "blink")
+    ("text-decoration-style" "solid" "double" "dotted" "dashed" "wavy")
+    ("text-overflow" "clip" "ellipsis")
+    ("text-shadow" color length)
+    ("text-underline-position" "auto" "under" "left" "right")
+    ("transform" "matrix(,,,,,)" "translate(,)" "translateX()" "translateY()"
+     "scale()" "scaleX()" "scaleY()" "rotate()" "skewX()" "skewY()" "none")
+    ("transform-origin" perspective-origin)
+    ("transform-style" "flat" "preserve-3d")
+    ("transition" transition-property transition-duration
+     transition-timing-function transition-delay)
+    ("transition-delay" time)
+    ("transition-duration" time)
+    ("transition-timing-function"
+     "ease" "linear" "ease-in" "ease-out" "ease-in-out" "cubic-bezier(,,,)")
+    ("transition-property" "none" "all" identifier)
+    ("word-wrap" overflow-wrap)
+    ("word-break" "normal" "break-all" "keep-all"))
   "A list of CSS properties and their possible values.")
 
 (defconst ac-css-value-classes
   '((absolute-size "xx-small" "x-small" "small" "medium" "large" "x-large"
                    "xx-large")
+    (align-common "flex-start" "flex-end" "center")
+    (align-stretch align-common "stretch")
     (border-style "none" "hidden" "dotted" "dashed" "solid" "double" "groove"
                   "ridge" "inset" "outset")
+    (border-width "thick" "medium" "thin")
     (color "aqua" "black" "blue" "fuchsia" "gray" "green" "lime" "maroon" "navy"
-           "olive" "orange" "purple" "red" "silver" "teal" "white" "yellow"
-           "rgb")
-    (counter "counter")
+           "olive" "orange" "purple" "red" "silver" "teal" "white" "yellow")
+    (counter "counter(,)")
     (family-name "Courier" "Helvetica" "Times")
     (generic-family "serif" "sans-serif" "cursive" "fantasy" "monospace")
     (generic-voice "male" "female" "child")
     (margin-width "auto") ;; length percentage
     (relative-size "larger" "smaller")
-    (shape "rect")
-    (uri "url"))
+    (shape "rect(,,,)")
+    (uri "url()"))
   "A list of CSS property value classes and their contents.")
+;; missing, because not completable
+;; <angle><frequency><identifier><integer><length><number><padding-width>
+;; <percentage><specific-voice><string><time><uri>
 
 (defconst ac-css-pseudo-classes
   '("active" "after" "before" "first" "first-child" "first-letter" "first-line"


### PR DESCRIPTION
In the previous PR (#476) the author deleted the source repository and left us with raw patches only. I made a branch and applied the changeset from that PR. I'm not sure if it should be merged as-is. One thing that seems strange is the inclusion of parens (and commas) in some candidates, like `matrix(,,,,,)`. From the diff it looks like we didn't have candidates like this before. Also, I imagine completing such a function would put the point after the closing paren - you'd then have to jump back to the beginning of the arguments list, which could be more distracting than completing to `matrix|` and pressing `(` from there. Things like `matrix(,,,,,)` are probably better suited for `yasnippet` than AC. In any case - we now have a PR that is merge-able, whether we do merge it or not :)