### PR TITLE
Fix unbalanced parentheses in maintainer email comment

### DIFF
--- a/auto-complete.el
+++ b/auto-complete.el
@@ -4,7 +4,7 @@
 ;; Copyright (C) 2020-2022  Jen-Chieh Shen
 
 ;; Author: Tomohiro Matsuyama <m2ym.pub@gmail.com>
-;; Maintainer: Jen-Chieh Shen <jcs090218@gmail.com
+;; Maintainer: Jen-Chieh Shen <jcs090218@gmail.com>
 ;; URL: https://github.com/auto-complete/auto-complete
 ;; Keywords: completion, convenience
 ;; Version: 1.5.1


### PR DESCRIPTION
This unclosed paren causes cascading build failures for Nix-based Emacs builds.

See
https://hydra.nix-community.org/build/11467643/nixlog/1
https://hydra.nix-community.org/eval/389312#tabs-now-fail