### PR TITLE
fix: Compilation failure of auto-complete-config

### DIFF
--- a/auto-complete-config.el
+++ b/auto-complete-config.el
@@ -31,7 +31,6 @@
 (declare-function semantic-format-tag-type "semantic/format")
 (declare-function semantic-format-tag-name "semantic/format")
 (declare-function yas-expand-snippet "yasnippet")
-(declare-function oref "eieio" (obj slot))
 
 
 
@@ -207,7 +206,7 @@
 (defun ac-semantic-action ()
   "No documentation."
   (when (and (boundp 'yas-minor-mode) yas-minor-mode)
-    (let* ((tag (car (last (oref (semantic-analyze-current-context) 'prefix))))
+    (let* ((tag (car (last (slot-value (semantic-analyze-current-context) 'prefix))))
            (class (semantic-tag-class tag))
            (args))
       (when (eq class 'function)


### PR DESCRIPTION
Compilation of auto-complete-config.el fails with the following error:

```
Debugger entered--Lisp error: (wrong-type-argument symbolp 'prefix)
  eieio--known-slot-name-p('prefix)
  eieio-oref--anon-cmacro((eieio-oref (semantic-analyze-current-context) ''prefix) (semantic-analyze-current-context) ''prefix)
  apply(eieio-oref--anon-cmacro (eieio-oref (semantic-analyze-current-context) ''prefix) ((semantic-analyze-current-context) ''prefix))
  macroexp--compiler-macro(eieio-oref--anon-cmacro (eieio-oref (semantic-analyze-current-context) ''prefix))
  macroexp--expand-all((oref (semantic-analyze-current-context) 'prefix))
(...snip...)
  macroexpand-all((defalias 'ac-semantic-action #'(lambda nil "No documentation." (when (and (boundp 'yas-minor-mode) yas-minor-mode) (let* ((tag ...) (class ...) (args)) (when (eq class ...) (setq args ...) (yas-expand-snippet ...)))))))
(...snip...)
```

This is due to misuse of `oref`. This patch replaces it with `slot-value`, which admits a quoted symbol.