### PR TITLE
Remove outdated `auto-compile-pkg.el`

### DIFF
--- a/auto-complete-pkg.el
+++ b/auto-complete-pkg.el
@@ -1,5 +1,0 @@
-(define-package "auto-complete"
-  "1.5.0"
-  "Auto Completion for GNU Emacs"
-  '((popup "0.5.0")
-    (cl-lib "0.5")))


### PR DESCRIPTION
The information in `<name>-pkg.el` did not agree with the information in `<name>.el`.  This pull-requests addresses that be removing the outdated `<name>-pkg.el`.

While the end-user package manager `package.el` expects a file `<name>-pkg.el`, this should only be generate by the package archive (such as GNU ELPA and MELPA), instead of being tracked in the upstream repository.

The tools used maintain the various *ELPA, do *not* use `<name>-pkg.el` as a data *source*, they only generate it it.

- `elpa-admin.el`, the tool used for GNU ELPA and NonGNU ELPA, does *not* use `<name>-pkg.el` as a data source and it never has.

- `package-build.el`, the tool used for Melpa, prefers `<name>.el` but *currently* falls back to get information missing from there from `<name>-pkg.el` instead. I am goint to change that; soon `<name>-pkg.el` will be ignored as a data source by this tool too.