### PR TITLE
Ensure ac-ignore-case "smart" option behaves distinctly

### DIFF
--- a/auto-complete.el
+++ b/auto-complete.el
@@ -1140,9 +1140,9 @@ You can not use it in source definition like (PREFIX . `NAME')."
 
 (defun ac-candidates ()
   "Produce candidates for current sources."
-  (cl-loop with completion-ignore-case = (or ac-ignore-case
-                                             (and (eq ac-ignore-case 'smart)
-                                                  (let ((case-fold-search nil)) (not (string-match "[[:upper:]]" ac-prefix)))))
+  (cl-loop with completion-ignore-case = (if (eq ac-ignore-case 'smart)
+                                             (let ((case-fold-search nil)) (not (string-match "[[:upper:]]" ac-prefix)))
+                                           ac-ignore-case)
            with case-fold-search = completion-ignore-case
            with prefix-len = (length ac-prefix)
            for source in ac-current-sources


### PR DESCRIPTION
Commit 504ca6d341fe2e850ad6bbcf4c7501f2c9d0598d seems to have introduced a bug.

Previously there was a check for whether `ac-ignore-case` was specifically `t`.  The check was changed to observe if `ac-ignore-case` was truthy.  `ac-ignore-case` was supposed to have a certain behavior when set to the symbol `smart`.  Unfortunately, since symbols are truthy, the code change caused both `t` and the symbol `smart` to trigger the same behavior, such that there was no smart case sensitivity anymore; both settings enabled unconditional case-sensitivity.

We could have just reverted that commit, but in the fix I'm providing here, I tried to provide a version of the branching logic that would utilize a truthy check - but this time, it should produce (what I believe to be) the intended behavior.

- Before: https://shareitdammit.com/6YcxwX2y - bug can be seen at the 00:28 mark in the video - the completions should have been case-sensitive here since the prefix contained a capital letter and `ac-ignore-case` was `smart`, but instead they are case-insensitive (just like when `ac-ignore-case` was `t`)
- After: https://shareitdammit.com/aTk3XzMY - correct results are given for each `ac-ignore-case` variant